### PR TITLE
+ ShEx equivalents for SHACL files

### DIFF
--- a/shex/catalog.shex
+++ b/shex/catalog.shex
@@ -1,0 +1,14 @@
+# SHACL-to-ShEx:
+PREFIX : <http://fairdatapoint.org/>
+PREFIX dash: <http://datashapes.org/dash#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:CatalogShape {
+  dct:issued  xsd:dateTime ? ;
+  dct:modified  xsd:dateTime ? ;
+  foaf:homePage  IRI ? ;
+  dcat:themeTaxonomy  IRI *
+}

--- a/shex/data-service.shex
+++ b/shex/data-service.shex
@@ -1,0 +1,14 @@
+# SHACL-to-ShEx:
+PREFIX : <http://fairdatapoint.org/>
+PREFIX dash: <http://datashapes.org/dash#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:DataServiceShape {
+  dcat:theme  IRI + ;
+  dcat:endpointURL  IRI ? ;
+  dcat:endpointDescription  IRI ? ;
+  dcat:landingPage  IRI ? ;
+  dcat:servesDataset  IRI ?
+}

--- a/shex/dataset.shex
+++ b/shex/dataset.shex
@@ -1,0 +1,15 @@
+# SHACL-to-ShEx:
+PREFIX : <http://fairdatapoint.org/>
+PREFIX dash: <http://datashapes.org/dash#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:DatasetShape {
+  dct:issued  xsd:dateTime ? ;
+  dct:modified  xsd:dateTime ? ;
+  dcat:theme  IRI + ;
+  dcat:contactPoint  IRI ? ;
+  dcat:keyword  LITERAL * ;
+  dcat:landingPage  IRI ?
+}

--- a/shex/distribution.shex
+++ b/shex/distribution.shex
@@ -1,0 +1,16 @@
+# SHACL-to-ShEx:
+PREFIX : <http://fairdatapoint.org/>
+PREFIX dash: <http://datashapes.org/dash#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:DistributionShape {
+  dct:issued  xsd:dateTime ? ;
+  dct:modified  xsd:dateTime ? ;
+  dcat:accessURL  IRI ? ;
+  dcat:downloadURL  IRI ? ;
+  dcat:mediaType  LITERAL ;
+  dcat:format  LITERAL ? ;
+  dcat:byteSize  LITERAL ?
+}

--- a/shex/patient-registry.shex
+++ b/shex/patient-registry.shex
@@ -1,0 +1,22 @@
+# SHACL-to-ShEx:
+PREFIX : <http://fairdatapoint.org/>
+PREFIX dash: <http://datashapes.org/dash#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX ejp: <http://purl.org/ejp-rd/vocabulary/>
+PREFIX sio: <http://semanticscience.org/resource/>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+:PatientRegistryShape {
+  dcat:theme  IRI + ;
+  dcat:keyword  LITERAL * ;
+  ejp:personalData  LITERAL AND xsd:boolean ;
+  foaf:page  IRI ? ;
+  ejp:populationCoverage  @:AnnotationShape *
+}
+
+
+:AnnotationShape {
+  rdfs:label  LITERAL AND  [ "National" "International" "Regional" "European" ] *
+}

--- a/shex/resource.shex
+++ b/shex/resource.shex
@@ -1,0 +1,27 @@
+# SHACL-to-ShEx:
+PREFIX : <http://fairdatapoint.org/>
+PREFIX dash: <http://datashapes.org/dash#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX ejp: <http://purl.org/ejp-rd/vocabulary/>
+
+:ResourceShape {
+  dct:title  LITERAL ;
+  dct:description  LITERAL ? ;
+  dct:hasVersion  LITERAL ;
+  dct:language  IRI ? ;
+  dct:license  IRI ? ;
+  dct:rights  IRI ? ;
+  ejp:personalData  LITERAL AND  [ "true" "false" ] ? ;
+  dct:publisher  @:AgentShape ;
+  ejp:vpConnection  IRI AND  [ ejp:VPDiscoverable ejp:VPContentDiscovery ] {0, 2} ;
+  foaf:logo  IRI ?
+}
+
+
+:AgentShape {
+  foaf:name  LITERAL ;
+  foaf:logo  IRI ?
+}


### PR DESCRIPTION
created by pasting into https://ericprud.github.io/shh/

shh doesn't copy non-semantic SHACL properties into ShEx annotations (haven't bothered) so `dash:editor` and `dash:viewer` don't appear in the ShEx.